### PR TITLE
Allow build job to be selected as a status check

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Defined an explicit name for the build job so that it can be selected as a branch status check